### PR TITLE
Update to live version and implement "Show Stats with 0 Rating"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ The location of the stat frame can be configured.
 For every stat can be decided whether it is shown or not. Furthermore, it can be chosen any color for any stat to highlight it.
 
 Following stats are currently supported:
-* All Primary Stats: 
-    - Strength
-    - Agility
-    - Intellect
-    - Stamina
-* Secondary Stats:
-    - Mastery
-    - Spell Crit
-    - Spell Haste
-    - Versatility
-    - Absorb
-    - Speed
+- All Primary Stats:
+    - Strength
+    - Agility
+    - Intellect
+    - Stamina
+- Secondary Stats:
+    - Mastery
+    - Spell Crit
+    - Spell Haste
+    - Versatility
+    - Absorb
+    - Speed
     - Armor

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # ShowMyStats
-World of Warcraft Addon that enables the user to display character stats. Find more information on https://www.curseforge.com/wow/addons/showmystats
+World of Warcraft Addon that enables the user to show desired stats on the screen. Supporting Game Version 9.0.1.
 
+
+
+Type /sms or /showmystats into your chat window to open the configuration panel.
+
+
+
+## Options
+
+The location of the stat frame can be configured.
+
+
+For every stat can be decided whether it is shown or not. Furthermore, it can be chosen any color for any stat to highlight it.
+
+Following stats are currently supported:
+* All Primary Stats: 
+    - Strength
+    - Agility
+    - Intellect
+    - Stamina
+* Secondary Stats:
+    - Mastery
+    - Spell Crit
+    - Spell Haste
+    - Versatility
+    - Absorb
+    - Speed
+    - Armor

--- a/ShowMyStats.toc
+++ b/ShowMyStats.toc
@@ -1,9 +1,9 @@
-## Interface: 90001
+## Interface: 110005
 ## Title: Show My Stats
 ## Notes: Simple Addon that enables to show chosen character stats on the screen
 ## SavedVariables: ShowMyStatsDB
 ## Author: Philipp Lars Harnisch
-## Version: 0.1
+## Version: 1.2.3
 
 embeds.xml
 


### PR DESCRIPTION
- Updated to live version, taken from 1.2.3 on Curseforge
- Implemented a checkbox for "Show Stats with 0 Rating"
  - Displayed under "Stat Configuration" category, this checkbox shows stats with 0 rating that are enabled in the list.
  - For example, "Avoidance" is enabled in the list, but you have 0 rating. The addon displays it as "Avoidance: 0%" when checked or removes it from the displayed list when unchecked.